### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ test {
 
 application {
     mainClass.set("pip.gui.Main")
+    applicationDefaultJvmArgs = ['-ea']
 }
 tasks.named('jar') {
     manifest { attributes('Main-Class': application.mainClass.get()) }

--- a/data/pip.txt
+++ b/data/pip.txt
@@ -1,2 +1,2 @@
 T | 1 | CS2103 assignments
-D | 0 | 2101 assignment | 2025-09-12T23:59
+D | 1 | 2101 assignment | 2025-09-12T23:59

--- a/src/main/java/pip/logic/Command.java
+++ b/src/main/java/pip/logic/Command.java
@@ -46,6 +46,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             if (args.isEmpty()) {
                 throw new PipException("The description of a todo cannot be empty :((");
             }
@@ -76,6 +77,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             if (!args.contains("/by")) {
                 throw new PipException("Usage: deadline <desc> /by <time>");
             }
@@ -113,6 +115,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             if (!args.contains("/from") || !args.contains("/to")) {
                 throw new PipException("Usage: event <desc> /from <start> /to <end>");
             }
@@ -146,6 +149,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             if (tasks.size() == 0) {
                 throw new PipException("Your list is empty! Add some tasks first :))");
             }
@@ -171,6 +175,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             int idx = Parser.parseIndex(args, tasks.size());
             tasks.get(idx).mark();
             storage.save(tasks.asList());
@@ -192,6 +197,7 @@ public abstract class Command {
         }
 
         @Override public void execute(TaskList tasks, Ui ui, Storage storage) throws PipException {
+            assert tasks != null && ui != null && storage != null : "tasks, ui, and storage must be set";
             int idx = Parser.parseIndex(args, tasks.size());
             tasks.get(idx).unmark();
             storage.save(tasks.asList());

--- a/src/main/java/pip/logic/Parser.java
+++ b/src/main/java/pip/logic/Parser.java
@@ -14,7 +14,6 @@ public class Parser {
      * @return Executable command corresponding to the input.
      * @throws PipException If the input is empty or the command is unknown.
      */
-    @SuppressWarnings("checkstyle:Indentation")
     public static Command parse(String fullCommand) throws PipException {
         String trimmed = fullCommand == null ? "" : fullCommand.trim();
         if (trimmed.isEmpty()) {

--- a/src/main/java/pip/model/TaskList.java
+++ b/src/main/java/pip/model/TaskList.java
@@ -18,6 +18,7 @@ public class TaskList {
      * @param loaded Initial tasks to copy into this list.
      */
     public TaskList(List<Task> loaded) {
+        assert loaded != null : "loaded list must not be null";
         this.tasks = new ArrayList<>(loaded);
     }
 
@@ -35,9 +36,9 @@ public class TaskList {
      *
      * @param i Zero-based index.
      * @return Task at the index.
-     * @throws IndexOutOfBoundsException If i is out of range.
      */
     public Task get(int i) {
+        assert i >= 0 && i < tasks.size() : "index out of range";
         return tasks.get(i);
     }
 
@@ -47,6 +48,7 @@ public class TaskList {
      * @param t Task to add.
      */
     public void add(Task t) {
+        assert t != null : "task must not be null";
         tasks.add(t);
     }
 
@@ -55,9 +57,9 @@ public class TaskList {
      *
      * @param i Zero-based index to remove.
      * @return The removed task.
-     * @throws IndexOutOfBoundsException If i is out of range.
      */
     public Task remove(int i) {
+        assert i >= 0 && i < tasks.size() : "index out of range";
         return tasks.remove(i);
     }
 

--- a/src/main/java/pip/storage/Storage.java
+++ b/src/main/java/pip/storage/Storage.java
@@ -27,6 +27,8 @@ public class Storage {
      * @param filePath Path to the persistent tasks file.
      */
     public Storage(String filePath) {
+        assert filePath != null && !filePath.isBlank() : "filePath must be non-empty";
+
         this.dataFile = Paths.get(filePath);
         this.dataDir = dataFile.getParent() != null ? dataFile.getParent() : Paths.get(".");
     }
@@ -75,6 +77,7 @@ public class Storage {
             }
             List<String> lines = new ArrayList<>();
             for (Task t : items) {
+                assert t != null : "task must not be null";
                 lines.add(t.toDataString());
             }
             Files.write(

--- a/src/main/java/pip/ui/Ui.java
+++ b/src/main/java/pip/ui/Ui.java
@@ -42,6 +42,7 @@ public class Ui {
      * @return The next line entered by the user (without the trailing newline).
      */
     public String readCommand(Scanner sc) {
+        assert sc != null : "Scanner must not be null";
         return sc.nextLine();
     }
 
@@ -72,10 +73,5 @@ public class Ui {
     /** Prints a non-fatal loading warning and continues with an empty task list. */
     public void showLoadingError() {
         out.println(INDENT + "Warning: could not load save file. Starting with an empty list.");
-    }
-
-    /** Exposes an explicit flush hook (useful when capturing output). */
-    public void flush() {
-        out.flush();
     }
 }


### PR DESCRIPTION
A few core classes rely on assumptions that were implicit, risking hidden bugs.

Add Java assert statements to document and verify these during development. User mistakes still raise PipException.

Let's assert in:
- Command
- Parser
- TaskList
- Storage
- UI

Using assert will fail fast in dev and are
off in production, so no user-facing impact.